### PR TITLE
fix: 모달 위치 조정 및 close 조건 추가.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,16 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "react-router-dom";
+import { SidebarProvider } from "./contexts/SidebarContext";
 import router from "./routes/route.tsx";
 
 const queryClient = new QueryClient();
 
 export default function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
+    <SidebarProvider>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </SidebarProvider>
   );
 }

--- a/src/components/chat/Sidebar.tsx
+++ b/src/components/chat/Sidebar.tsx
@@ -25,12 +25,12 @@ export default function HomeSidebar({ open, onClose }: Props) {
   return (
     <>
       <div
-        className={`absolute inset-0 z-40 bg-black/20 transition-opacity ${open ? "opacity-100" : "pointer-events-none opacity-0"}`}
+        className={`absolute inset-0 z-[91] bg-black/20 transition-opacity ${open ? "opacity-100" : "pointer-events-none opacity-0"}`}
         onClick={onClose}
         aria-hidden={!open}
       />
       <aside
-        className={`absolute left-0 top-0 z-50 h-full w-[86vw] max-w-[340px] bg-[#F5F5F5] px-6 py-8 shadow-xl transition-transform duration-300 ${open ? "translate-x-0" : "-translate-x-full"}`}
+        className={`absolute left-0 top-0 z-[92] h-full w-[86vw] max-w-[340px] bg-[#F5F5F5] px-6 py-8 shadow-xl transition-transform duration-300 ${open ? "translate-x-0" : "-translate-x-full"}`}
         aria-hidden={!open}
       >
         <div className="mb-8">

--- a/src/components/map/BuildingDetailModal.tsx
+++ b/src/components/map/BuildingDetailModal.tsx
@@ -1,3 +1,5 @@
+import { useContext, useEffect } from "react";
+import { SidebarContext } from "../../contexts/SidebarContext";
 import type { NftGoodsItem } from "../../apis/blockchain/blockchain";
 import BalancePill from "../common/BalancePill";
 
@@ -26,6 +28,14 @@ export default function BuildingDetailModal({
   purchaseMessage,
   closeLabel = "map",
 }: BuildingDetailModalProps) {
+  const sidebarContext = useContext(SidebarContext);
+
+  useEffect(() => {
+    if (item && sidebarContext?.open) {
+      onClose();
+    }
+  }, [sidebarContext?.open]);
+
   if (!item) return null;
 
   const isSold = item.isSold;
@@ -39,13 +49,20 @@ export default function BuildingDetailModal({
     numericBalance < numericPrice;
 
   return (
-    <div
-      className="absolute inset-x-0 bottom-0 z-[80]"
-      onClick={(event) => event.stopPropagation()}
-    >
-      {balance !== undefined && (
-        <BalancePill balance={balance} className="mb-2 ml-auto mr-4" />
-      )}
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-[79]"
+        onClick={onClose}
+      />
+
+      <div
+        className="fixed inset-x-0 bottom-0 z-[80]"
+        onClick={(event) => event.stopPropagation()}
+      >
+        {balance !== undefined && (
+          <BalancePill balance={balance} className="mb-2 ml-auto mr-4" />
+        )}
 
       <div className="max-h-[75vh] min-h-[62vh] overflow-y-auto rounded-t-3xl bg-[#F5F5F4] p-5 shadow-[0_-8px_24px_rgba(0,0,0,0.18)]">
         <span
@@ -115,5 +132,6 @@ export default function BuildingDetailModal({
         </button>
       </div>
     </div>
+    </>
   );
 }

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, ReactNode, useState } from "react";
+import { createContext, useState } from "react";
+import type { ReactNode } from "react";
 
 type SidebarContextType = {
   open: boolean;

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, ReactNode, useState } from "react";
+
+type SidebarContextType = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+};
+
+export const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
+
+export function SidebarProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <SidebarContext.Provider value={{ open, setOpen }}>
+      {children}
+    </SidebarContext.Provider>
+  );
+}

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { Outlet, useLocation } from "react-router-dom";
+import { SidebarContext } from "../contexts/SidebarContext";
 import MobileLayout from "../components/common/MobileLayout.tsx";
 import HomeSidebar from "../components/chat/Sidebar.tsx";
 
@@ -7,14 +8,20 @@ export default function RootLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { pathname } = useLocation();
   const isAuthPage = pathname.startsWith("/auth");
+  const sidebarContext = useContext(SidebarContext);
+
+  const handleSetSidebarOpen = (open: boolean) => {
+    setSidebarOpen(open);
+    sidebarContext?.setOpen(open);
+  };
 
   return (
     <MobileLayout>
       {!isAuthPage && (
         <button
           type="button"
-          onClick={() => setSidebarOpen(true)}
-          className="absolute left-5 top-6 z-30 flex h-14 w-14 items-center justify-center rounded-2xl bg-white shadow-sm border border-gray-100 text-[#001F3F]"
+          onClick={() => handleSetSidebarOpen(true)}
+          className="absolute left-5 top-6 z-[90] flex h-14 w-14 items-center justify-center rounded-2xl bg-white shadow-sm border border-gray-100 text-[#001F3F]"
           aria-label="Open menu"
         >
           <span className="flex flex-col gap-1">
@@ -25,7 +32,7 @@ export default function RootLayout() {
         </button>
       )}
       <Outlet />
-      {!isAuthPage && <HomeSidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />}
+      {!isAuthPage && <HomeSidebar open={sidebarOpen} onClose={() => handleSetSidebarOpen(false)} />}
     </MobileLayout>  
   );
 }


### PR DESCRIPTION
## 🎯 지식 요청 관리 및 모달 UX 개선

### 📋 작업 사항

#### 1) BuildingDetailModal UX 개선
- **레이아웃 고정화** - 스크롤 위치와 무관하게 항상 현재 보이는 화면 하단에 고정 (absolute → fixed)
- **배경 클릭 닫기** - 모달 뒤 투명 backdrop 추가, 클릭 시 모달 자동 닫힘
- **사이드바 연동** - SidebarContext 추가로 햄버거 버튼 클릭 시 모달 자동 닫힘
- **z-index 정리** - 모달(79-80) / 사이드바(90-92)로 계층 명확화

### 🔧 기술 개선사항
- **Context API** - SidebarContext로 전역 사이드바 상태 관리
- **모달 계층 관리** - Fixed positioning + 동적 z-index로 안정적 UI 흐름

### ✅ 포함 커밋
- BuildingDetailModal 고정 레이아웃 및 상호작용 개선
- SidebarContext 추가
- 빌드 오류 수정

### 📝 테스트 체크리스트
- [ ] 관리자 대시보드에서 상태 필터 전환 동작 확인
- [ ] 요청 승인/반려 API 호출 성공 확인
- [ ] BuildingDetailModal 스크롤 시에도 화면 하단에 고정 확인
- [ ] 모달 배경 클릭 시 닫힘 확인
- [ ] 사이드바 햄버거 버튼 클릭 시 열린 모달 자동 닫힘 확인
- [ ] pnpm run build 성공 확인