### PR TITLE
Feat/nft skeleton loading

### DIFF
--- a/src/components/common/AnimatedBottomSheet.tsx
+++ b/src/components/common/AnimatedBottomSheet.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+type AnimatedBottomSheetProps = {
+  open: boolean;
+  onBackdropClick: () => void;
+  children: ReactNode;
+  durationMs?: number;
+  onExited?: () => void;
+};
+
+export default function AnimatedBottomSheet({
+  open,
+  onBackdropClick,
+  children,
+  durationMs = 280,
+  onExited,
+}: AnimatedBottomSheetProps) {
+  const [shouldRender, setShouldRender] = useState(open);
+  const [visible, setVisible] = useState(false);
+  const closeTimeoutRef = useRef<number | null>(null);
+  const openRaf1Ref = useRef<number | null>(null);
+  const openRaf2Ref = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (closeTimeoutRef.current) {
+      window.clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
+    }
+    if (openRaf1Ref.current) {
+      window.cancelAnimationFrame(openRaf1Ref.current);
+      openRaf1Ref.current = null;
+    }
+    if (openRaf2Ref.current) {
+      window.cancelAnimationFrame(openRaf2Ref.current);
+      openRaf2Ref.current = null;
+    }
+
+    if (open) {
+      setShouldRender(true);
+      setVisible(false);
+      openRaf1Ref.current = window.requestAnimationFrame(() => {
+        openRaf2Ref.current = window.requestAnimationFrame(() => {
+          setVisible(true);
+          openRaf2Ref.current = null;
+        });
+        openRaf1Ref.current = null;
+      });
+      return;
+    }
+
+    setVisible(false);
+    closeTimeoutRef.current = window.setTimeout(() => {
+      setShouldRender(false);
+      onExited?.();
+      closeTimeoutRef.current = null;
+    }, durationMs);
+
+    return () => {
+      if (closeTimeoutRef.current) {
+        window.clearTimeout(closeTimeoutRef.current);
+        closeTimeoutRef.current = null;
+      }
+      if (openRaf1Ref.current) {
+        window.cancelAnimationFrame(openRaf1Ref.current);
+        openRaf1Ref.current = null;
+      }
+      if (openRaf2Ref.current) {
+        window.cancelAnimationFrame(openRaf2Ref.current);
+        openRaf2Ref.current = null;
+      }
+    };
+  }, [open, durationMs, onExited]);
+
+  if (!shouldRender) return null;
+
+  return (
+    <>
+      <div
+        className={`fixed inset-0 z-[79] bg-black/25 transition-opacity duration-300 ${
+          visible ? "opacity-100" : "opacity-0"
+        }`}
+        onClick={onBackdropClick}
+      />
+
+      <div
+        className={`fixed inset-x-0 bottom-0 z-[80] transition-all duration-300 ${
+          visible ? "translate-y-0 opacity-100" : "translate-y-8 opacity-0"
+        }`}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {children}
+      </div>
+    </>
+  );
+}

--- a/src/components/map/BuildingDetailModal.tsx
+++ b/src/components/map/BuildingDetailModal.tsx
@@ -1,6 +1,7 @@
-import { useContext, useEffect } from "react";
+import { useContext, useEffect, useState } from "react";
 import { SidebarContext } from "../../contexts/SidebarContext";
 import type { NftGoodsItem } from "../../apis/blockchain/blockchain";
+import AnimatedBottomSheet from "../common/AnimatedBottomSheet";
 import BalancePill from "../common/BalancePill";
 
 type BuildingDetailModalProps = {
@@ -29,109 +30,111 @@ export default function BuildingDetailModal({
   closeLabel = "map",
 }: BuildingDetailModalProps) {
   const sidebarContext = useContext(SidebarContext);
+  const [displayedItem, setDisplayedItem] = useState<NftGoodsItem | null>(item);
 
   useEffect(() => {
-    if (item && sidebarContext?.open) {
+    if (item) {
+      setDisplayedItem(item);
+    }
+  }, [item]);
+
+  useEffect(() => {
+    if (displayedItem && sidebarContext?.open) {
       onClose();
     }
-  }, [sidebarContext?.open]);
+  }, [sidebarContext?.open, displayedItem, onClose]);
 
-  if (!item) return null;
+  const open = Boolean(item);
+  const currentItem = displayedItem ?? item;
+  if (!currentItem && !open) return null;
 
-  const isSold = item.isSold;
-  const owner = isSold ? item.owner : null;
-  const txHash = isSold ? item.txHash : null;
+  const isSold = currentItem?.isSold ?? false;
+  const owner = isSold ? currentItem?.owner ?? null : null;
+  const txHash = isSold ? currentItem?.txHash ?? null : null;
   const numericBalance = Number(balance);
-  const numericPrice = Number(item.price);
+  const numericPrice = Number(currentItem?.price ?? 0);
   const isInsufficientBalance =
     Number.isFinite(numericBalance) &&
     Number.isFinite(numericPrice) &&
     numericBalance < numericPrice;
 
   return (
-    <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-[79]"
-        onClick={onClose}
-      />
-
-      <div
-        className="fixed inset-x-0 bottom-0 z-[80]"
-        onClick={(event) => event.stopPropagation()}
-      >
+    <AnimatedBottomSheet
+      open={open}
+      onBackdropClick={onClose}
+      onExited={() => setDisplayedItem(null)}
+    >
         {balance !== undefined && (
           <BalancePill balance={balance} className="mb-2 ml-auto mr-4" />
         )}
 
-      <div className="max-h-[75vh] min-h-[62vh] overflow-y-auto rounded-t-3xl bg-[#F5F5F4] p-5 shadow-[0_-8px_24px_rgba(0,0,0,0.18)]">
-        <span
-          className="inline-flex rounded-full border border-[#A8A29F] bg-[#F5F5F4] px-2.5 py-0.5 text-[10px] font-medium text-[#44403D]"
-        >
-          {isSold ? "Sold Out" : "Available"}
-        </span>
+        <div className="max-h-[75vh] min-h-[62vh] overflow-y-auto rounded-t-3xl bg-[#F5F5F4] p-5 shadow-[0_-8px_24px_rgba(0,0,0,0.18)]">
+          <span
+            className="inline-flex rounded-full border border-[#A8A29F] bg-[#F5F5F4] px-2.5 py-0.5 text-[10px] font-medium text-[#44403D]"
+          >
+            {isSold ? "Sold Out" : "Available"}
+          </span>
 
-        <h2 className="mt-3 text-3xl font-semibold tracking-tight text-[#10314f]">
-          {item.name}
-        </h2>
-        <p className="mt-3 text-[14px] leading-relaxed text-slate-600">
-          {item.description}
-        </p>
-
-        <dl className="mt-6 space-y-2 text-[12px] text-slate-700">
-          <div className="grid grid-cols-[110px_1fr] gap-2">
-            <dt className="text-slate-500">Metadata</dt>
-            <dd className="truncate">{formatShort(item.metadataUrl)}</dd>
-          </div>
-          <div className="grid grid-cols-[110px_1fr] gap-2">
-            <dt className="text-slate-500">Owner</dt>
-            <dd>{formatShort(owner, "-")}</dd>
-          </div>
-          <div className="grid grid-cols-[110px_1fr] gap-2">
-            <dt className="text-slate-500">Tx Hash</dt>
-            <dd>{formatShort(txHash, "-")}</dd>
-          </div>
-        </dl>
-
-        <div className="mt-8 flex items-end gap-2 text-left">
-          <p className="text-4xl font-bold leading-none text-[#fc5100]">
-            {item.price}
+          <h2 className="mt-3 text-3xl font-semibold tracking-tight text-[#10314f]">
+            {currentItem?.name}
+          </h2>
+          <p className="mt-3 text-[14px] leading-relaxed text-slate-600">
+            {currentItem?.description}
           </p>
-          <p className="text-lg font-semibold text-slate-600">tokens</p>
+
+          <dl className="mt-6 space-y-2 text-[12px] text-slate-700">
+            <div className="grid grid-cols-[110px_1fr] gap-2">
+              <dt className="text-slate-500">Metadata</dt>
+              <dd className="truncate">{formatShort(currentItem?.metadataUrl)}</dd>
+            </div>
+            <div className="grid grid-cols-[110px_1fr] gap-2">
+              <dt className="text-slate-500">Owner</dt>
+              <dd>{formatShort(owner, "-")}</dd>
+            </div>
+            <div className="grid grid-cols-[110px_1fr] gap-2">
+              <dt className="text-slate-500">Tx Hash</dt>
+              <dd>{formatShort(txHash, "-")}</dd>
+            </div>
+          </dl>
+
+          <div className="mt-8 flex items-end gap-2 text-left">
+            <p className="text-4xl font-bold leading-none text-[#fc5100]">
+              {currentItem?.price}
+            </p>
+            <p className="text-lg font-semibold text-slate-600">tokens</p>
+          </div>
+
+          {purchaseMessage && (
+            <p className="mt-4 rounded-lg bg-white/70 px-3 py-2 text-sm text-slate-700">
+              {purchaseMessage}
+            </p>
+          )}
+
+          {!isSold && isInsufficientBalance && (
+            <p className="mt-4 text-center text-[12px] text-[#fc5100]">
+              Insufficient balance · Earn more credits
+            </p>
+          )}
+
+          <button
+            onClick={onPurchase}
+            disabled={isSold || isPurchasing || isInsufficientBalance}
+            className="mt-2 w-full rounded-xl bg-[#fc5100] py-3.5 text-base font-medium text-white disabled:cursor-not-allowed disabled:bg-slate-300"
+          >
+            {isSold
+              ? "Sold Out"
+              : isPurchasing
+                ? "Purchasing..."
+                : `Purchase · ${currentItem?.price ?? 0} tokens`}
+          </button>
+
+          <button
+            onClick={onClose}
+            className="mt-3 w-full py-2 text-[15px] text-[#78716D] hover:text-[#10314f]"
+          >
+            ← Go back to {closeLabel}
+          </button>
         </div>
-
-        {purchaseMessage && (
-          <p className="mt-4 rounded-lg bg-white/70 px-3 py-2 text-sm text-slate-700">
-            {purchaseMessage}
-          </p>
-        )}
-
-        {!isSold && isInsufficientBalance && (
-          <p className="mt-4 text-center text-[12px] text-[#fc5100]">
-            Insufficient balance · Earn more credits
-          </p>
-        )}
-
-        <button
-          onClick={onPurchase}
-          disabled={isSold || isPurchasing || isInsufficientBalance}
-          className="mt-2 w-full rounded-xl bg-[#fc5100] py-3.5 text-base font-medium text-white disabled:cursor-not-allowed disabled:bg-slate-300"
-        >
-          {isSold
-            ? "Sold Out"
-            : isPurchasing
-              ? "Purchasing..."
-              : `Purchase · ${item.price} tokens`}
-        </button>
-
-        <button
-          onClick={onClose}
-          className="mt-3 w-full py-2 text-[15px] text-[#78716D] - hover:text-[#10314f]"
-        >
-          ← Go back to {closeLabel}
-        </button>
-      </div>
-    </div>
-    </>
+    </AnimatedBottomSheet>
   );
 }

--- a/src/components/shop/NftCardSkeleton.tsx
+++ b/src/components/shop/NftCardSkeleton.tsx
@@ -1,0 +1,13 @@
+export default function NftCardSkeleton() {
+  return (
+    <div className="aspect-square animate-pulse rounded-xl bg-slate-200">
+      <div className="h-full w-full flex flex-col p-3">
+        <div className="h-5 w-16 rounded bg-slate-300 mb-auto" />
+        <div className="space-y-2 mt-2">
+          <div className="h-4 w-full rounded bg-slate-300" />
+          <div className="h-4 w-3/4 rounded bg-slate-300" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shop/NftGridSection.tsx
+++ b/src/components/shop/NftGridSection.tsx
@@ -1,5 +1,6 @@
 import type { NftGoodsItem } from "../../apis/blockchain/blockchain";
 import NftBuildingCard from "./NftBuildingCard";
+import NftCardSkeleton from "./NftCardSkeleton";
 
 type NftGridSectionProps = {
   title: string;
@@ -8,6 +9,7 @@ type NftGridSectionProps = {
   badgeText?: string;
   emptyMessage?: string;
   showComingSoonPlaceholder?: boolean;
+  isLoading?: boolean;
 };
 
 export default function NftGridSection({
@@ -17,12 +19,21 @@ export default function NftGridSection({
   badgeText,
   emptyMessage,
   showComingSoonPlaceholder = false,
+  isLoading = false,
 }: NftGridSectionProps) {
+  const skeletonCount = 4;
+
   return (
     <section>
       <p className="mb-3 text-[12px] font-bold tracking-widest text-[#78716D]">{title}</p>
 
-      {items.length === 0 && emptyMessage ? (
+      {isLoading ? (
+        <div className="grid grid-cols-2 gap-3">
+          {Array.from({ length: skeletonCount }).map((_, idx) => (
+            <NftCardSkeleton key={idx} />
+          ))}
+        </div>
+      ) : items.length === 0 && emptyMessage ? (
         <p className="text-[12px] text-[#78716D]">{emptyMessage}</p>
       ) : (
         <div className="grid grid-cols-2 gap-3">

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -36,10 +36,12 @@ export default function ProfilePage() {
   const [balance, setBalance] = useState("12");
   const [ownedNfts, setOwnedNfts] = useState<NftGoodsItem[]>([]);
   const [selectedItem, setSelectedItem] = useState<NftGoodsItem | null>(null);
+  const [loading, setLoading] = useState(true);
 
   const accessToken = localStorage.getItem("accessToken") ?? undefined;
 
   useEffect(() => {
+    setLoading(true);
     Promise.allSettled([getHsBalance(accessToken), getNftGoods(accessToken)])
       .then(([balanceResult, goodsResult]) => {
         if (balanceResult.status === "fulfilled") {
@@ -54,6 +56,9 @@ export default function ProfilePage() {
       })
       .catch(() => {
         setOwnedNfts([]);
+      })
+      .finally(() => {
+        setLoading(false);
       });
   }, [accessToken]);
 
@@ -135,6 +140,7 @@ export default function ProfilePage() {
           onItemClick={setSelectedItem}
           badgeText="Owned"
           emptyMessage="소유한 건물이 없습니다."
+          isLoading={loading}
         />
       </section>
 

--- a/src/pages/shop/ShopPage.tsx
+++ b/src/pages/shop/ShopPage.tsx
@@ -83,6 +83,7 @@ export default function ShopPage() {
               onItemClick={setSelectedItem}
               badgeText="Owned"
               emptyMessage="소유한 NFT가 없습니다."
+              isLoading={loading}
             />
 
             <div className="border-t border-[#d6d3d1]" />
@@ -92,6 +93,7 @@ export default function ShopPage() {
               items={available}
               onItemClick={setSelectedItem}
               showComingSoonPlaceholder
+              isLoading={loading}
             />
           </>
         )}


### PR DESCRIPTION
## ✨ NFT 로딩 UX 개선: 스켈레톤 UI + 디테일 모달 애니메이션

### 작업 배경
상품/건물 목록 로딩 중 사용자 대기 경험을 개선하고, 디테일 모달의 등장/퇴장 전환을 자연스럽게 만들어 전체 UI 체감 품질을 높였습니다.

---

## 1) 스켈레톤 UI 추가

### 변경 내용
- `NftCardSkeleton` 컴포넌트 신규 추가
- `NftGridSection`에 `isLoading` prop 추가
- 로딩 중에는 카드 대신 스켈레톤 카드(4개) 렌더링
- 로딩 완료 후 기존 카드/빈 상태 UI로 전환

### 적용 파일
- [src/components/shop/NftCardSkeleton.tsx](src/components/shop/NftCardSkeleton.tsx)
- [src/components/shop/NftGridSection.tsx](src/components/shop/NftGridSection.tsx)
- [src/pages/shop/ShopPage.tsx](src/pages/shop/ShopPage.tsx)
- [src/pages/profile/ProfilePage.tsx](src/pages/profile/ProfilePage.tsx)

---

## 2) 디테일 모달 애니메이션 추가 및 분리

### 변경 내용
- 모달 열림/닫힘 시 전환 애니메이션 적용
  - 바텀시트: `translateY + opacity`
  - 백드롭: `opacity fade`
- 닫힘 애니메이션이 끝난 뒤 언마운트되도록 처리
- 애니메이션 로직을 공용 컴포넌트로 분리하여 재사용 가능 구조로 개선

### 적용 파일
- [src/components/common/AnimatedBottomSheet.tsx](src/components/common/AnimatedBottomSheet.tsx) (신규)
- [src/components/map/BuildingDetailModal.tsx](src/components/map/BuildingDetailModal.tsx)

---

## 3) 함께 반영된 UX 보완
- 모달 백드롭 클릭 시 닫힘
- 사이드바 햄버거 버튼 클릭 시 열린 디테일 모달 자동 닫힘 (기존 의도 반영)

### 관련 파일
- [src/contexts/SidebarContext.tsx](src/contexts/SidebarContext.tsx) (신규)
- [src/layouts/RootLayout.tsx](src/layouts/RootLayout.tsx)
- [src/App.tsx](src/App.tsx)

---