### PR TITLE
Feat/admin and my page api 연동 및 리팩토링

### DIFF
--- a/src/apis/blockchain/blockchain.ts
+++ b/src/apis/blockchain/blockchain.ts
@@ -164,7 +164,33 @@ const MOCK_NFT_GOODS: NftGoodsItem[] = [
   },
 ];
 
-const USE_MOCK = true;
+const USE_MOCK = false;
+
+export interface MyPageNftItem {
+  index: number;
+  name: string;
+  description: string;
+  price: string;
+  imageUrl: string;
+  metadataUrl: string;
+  txHash: string;
+}
+
+export interface MyPageResponse {
+  email: string;
+  walletAddress: string;
+  hsTokenBalance: string;
+  nftCount: number;
+  nfts: MyPageNftItem[];
+}
+
+export const getMyPage = async (accessToken?: string): Promise<MyPageResponse> => {
+  const { data } = await axiosInstance.get<MyPageResponse>(
+    "/users/mypage",
+    createAuthConfig(accessToken),
+  );
+  return data;
+};
 
 export const getNftGoods = async (accessToken?: string): Promise<NftGoodsItem[]> => {
   if (USE_MOCK) {

--- a/src/apis/knowledge/knowledge.ts
+++ b/src/apis/knowledge/knowledge.ts
@@ -2,11 +2,9 @@ import { API_BASE_URL, getBearerAuthHeaders, parseApiResponse } from "../httpCli
 import type {
   KnowledgeDeleteBody,
   KnowledgeSubmissionItem,
-  KnowledgeSubmissionStatus,
   KnowledgeListParams,
   KnowledgeListResponse,
   KnowledgeMutationResponse,
-  KnowledgeSubmissionItem,
   KnowledgeSubmissionListParams,
   KnowledgeSubmitBody,
   KnowledgeUpdateBody,
@@ -90,4 +88,9 @@ export async function fetchMyKnowledgeSubmissions(
     },
   );
   return parseApiResponse<KnowledgeSubmissionItem[]>(response);
+}
+
+/** @deprecated use fetchMyKnowledgeSubmissions */
+export async function fetchMySubmissions(): Promise<KnowledgeSubmissionItem[]> {
+  return fetchMyKnowledgeSubmissions();
 }

--- a/src/pages/DailyQPage.tsx
+++ b/src/pages/DailyQPage.tsx
@@ -1,26 +1,20 @@
 import { useEffect, useMemo, useState } from "react";
-import { fetchMyKnowledgeSubmissions, submitKnowledge } from "../apis/knowledge/knowledge";
-import type { KnowledgeSubmissionItem, KnowledgeSubmissionStatus } from "../apis/knowledge/types";
+import { useNavigate } from "react-router-dom";
+import { submitKnowledge } from "../apis/knowledge/knowledge";
 import { fetchNextQuestion, type QuestionItem } from "../apis/questions/questions";
 
-type Step = "swipe" | "write" | "submit" | "submitted" | "history";
-
-const statusColor: Record<KnowledgeSubmissionStatus, string> = {
-  APPROVED: "text-emerald-600 bg-emerald-50",
-  PENDING: "text-amber-600 bg-amber-50",
-  REJECTED: "text-rose-600 bg-rose-50",
-};
+type Step = "swipe" | "write" | "submit" | "submitted";
 
 const primaryBtn = "w-full rounded-xl bg-[#FF5C00] py-3 text-center text-sm font-semibold text-white";
 const secondaryBtn =
   "w-full rounded-xl border border-gray-300 bg-white py-3 text-center text-sm font-semibold text-gray-700";
 
 export default function DailyQPage() {
+  const navigate = useNavigate();
   const [step, setStep] = useState<Step>("swipe");
   const [answer, setAnswer] = useState("");
   const [question, setQuestion] = useState<QuestionItem | null>(null);
   const [remaining, setRemaining] = useState(0);
-  const [history, setHistory] = useState<KnowledgeSubmissionItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -42,22 +36,8 @@ export default function DailyQPage() {
     }
   };
 
-  const loadHistory = async (status?: KnowledgeSubmissionStatus) => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const items = await fetchMyKnowledgeSubmissions(status ? { status } : {});
-      setHistory(items);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "제출 기록을 불러오지 못했습니다.");
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   useEffect(() => {
     void loadQuestion();
-    void loadHistory();
   }, []);
 
   const handleSubmit = async () => {
@@ -72,7 +52,7 @@ export default function DailyQPage() {
       });
       setStep("submitted");
       setAnswer("");
-      await Promise.all([loadQuestion(), loadHistory()]);
+      await loadQuestion();
     } catch (e) {
       setError(e instanceof Error ? e.message : "제출 중 오류가 발생했습니다.");
     } finally {
@@ -136,7 +116,7 @@ export default function DailyQPage() {
                     <button
                       type="button"
                       className="w-full text-center text-sm font-medium text-gray-500"
-                      onClick={() => setStep("history")}
+                      onClick={() => setStep("swipe")}
                     >
                       Go back to questions
                     </button>
@@ -176,7 +156,7 @@ export default function DailyQPage() {
             Admin will review your answer. Credits will be added once approved.
           </p>
           <div className="mt-10 w-full max-w-sm space-y-2">
-            <button type="button" className={primaryBtn} onClick={() => setStep("history")}>
+            <button type="button" className={primaryBtn} onClick={() => navigate("/daily-q/history")}>
               View answer history
             </button>
             <button
@@ -193,56 +173,7 @@ export default function DailyQPage() {
         </section>
       )}
 
-      {step === "history" && (
-        <section className="min-h-[78vh]">
-          <div className="mb-4 flex items-center justify-between">
-            <h2 className="text-4xl font-semibold text-[#0f263a]">Daily Q History</h2>
-            <button type="button" className={secondaryBtn} onClick={() => setStep("swipe")}>
-              Back
-            </button>
-          </div>
-          <div className="mb-3 flex gap-2">
-            <button type="button" className={secondaryBtn} onClick={() => void loadHistory()}>
-              ALL
-            </button>
-            <button type="button" className={secondaryBtn} onClick={() => void loadHistory("PENDING")}>
-              PENDING
-            </button>
-            <button type="button" className={secondaryBtn} onClick={() => void loadHistory("APPROVED")}>
-              APPROVED
-            </button>
-            <button type="button" className={secondaryBtn} onClick={() => void loadHistory("REJECTED")}>
-              REJECTED
-            </button>
-          </div>
-          <div className="space-y-3">
-            {history.map((item) => (
-              <article key={item.id} className="rounded-xl border border-gray-200 bg-white p-3">
-                <div className="mb-1 flex items-start justify-between gap-3">
-                  <p className="text-xs font-semibold text-slate-700">
-                    {item.originalQuestion ?? "질문 텍스트 없음"}
-                  </p>
-                  <span
-                    className={`shrink-0 rounded px-2 py-0.5 text-[10px] font-semibold ${
-                      statusColor[item.status]
-                    }`}
-                  >
-                    {item.status}
-                  </span>
-                </div>
-                <p className="text-xs leading-relaxed text-gray-500">{item.content}</p>
-                <div className="mt-2 flex items-center justify-between text-[11px] text-gray-400">
-                  <span>{new Date(item.createdAt).toLocaleString()}</span>
-                  <span>{item.type}</span>
-                </div>
-              </article>
-            ))}
-            {!isLoading && history.length === 0 ? (
-              <p className="py-10 text-center text-sm text-gray-500">제출 기록이 없습니다.</p>
-            ) : null}
-          </div>
-        </section>
-      )}
+
     </main>
   );
 }

--- a/src/pages/daily-q/DailyQHistoryPage.tsx
+++ b/src/pages/daily-q/DailyQHistoryPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { fetchMySubmissions } from "../../apis/knowledge/knowledge";
+import { fetchMyKnowledgeSubmissions } from "../../apis/knowledge/knowledge";
 import type { KnowledgeSubmissionItem, KnowledgeSubmissionStatus } from "../../apis/knowledge/types";
 import { KNOWLEDGE_CATEGORY_LABELS } from "../../apis/knowledge/types";
 import { SIDEBAR_BUTTON_SAFE_TOP_CLASS } from "../../utils/layout";
@@ -33,7 +33,7 @@ export default function DailyQHistoryPage() {
 
   useEffect(() => {
     setLoading(true);
-    fetchMySubmissions()
+    fetchMyKnowledgeSubmissions()
       .then(setItems)
       .catch(() => setItems([]))
       .finally(() => setLoading(false));

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   getHsBalance,
   getNftGoods,

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -1,168 +1,83 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  getMyPage,
-  type NftGoodsItem,
-} from "../../apis/blockchain/blockchain";
+import { getMyPage, type NftGoodsItem } from "../../apis/blockchain/blockchain";
 import { fetchMyKnowledgeSubmissions } from "../../apis/knowledge/knowledge";
 import { clearAuthTokens } from "../../apis/auth/auth";
 import { useAuthStore } from "../../store/useAuthStore";
+import { countCreateSubmissionStats } from "../../features/knowledge/knowledgeSubmissionStats";
 import { SIDEBAR_BUTTON_SAFE_TOP_CLASS } from "../../utils/layout";
 import NftGridSection from "../../components/shop/NftGridSection";
 import BuildingDetailModal from "../../components/map/BuildingDetailModal";
-import { countCreateSubmissionStats } from "../../features/knowledge/knowledgeSubmissionStats";
+import ProfileHeader from "./components/ProfileHeader";
+import DailyQStatsSection from "./components/DailyQStatsSection";
+import AccountSection from "./components/AccountSection";
+import LogoutModal from "./components/LogoutModal";
 
-type ProfileDailyQStats = {
-  received: number;
-  pending: number;
-  notCredited: number;
-};
+type DailyQStats = { received: number; pending: number; notCredited: number };
 
-const defaultDailyQStats: ProfileDailyQStats = {
-  received: 0,
-  pending: 0,
-  notCredited: 0,
-};
-
-
+const DEFAULT_STATS: DailyQStats = { received: 0, pending: 0, notCredited: 0 };
 
 export default function ProfilePage() {
   const navigate = useNavigate();
   const tempUser = useAuthStore((state) => state.tempUser);
+  const accessToken = localStorage.getItem("accessToken") ?? undefined;
+
   const [balance, setBalance] = useState("");
   const [email, setEmail] = useState("");
   const [walletAddress, setWalletAddress] = useState("");
   const [ownedNfts, setOwnedNfts] = useState<NftGoodsItem[]>([]);
   const [selectedItem, setSelectedItem] = useState<NftGoodsItem | null>(null);
-  const [showLogoutModal, setShowLogoutModal] = useState(false);
+  const [dailyQStats, setDailyQStats] = useState<DailyQStats>(DEFAULT_STATS);
   const [loading, setLoading] = useState(true);
-  const [submissionStats, setSubmissionStats] = useState<ProfileDailyQStats>(defaultDailyQStats);
-
-  const accessToken = localStorage.getItem("accessToken") ?? undefined;
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
 
   useEffect(() => {
     setLoading(true);
-    Promise.allSettled([
-      getMyPage(accessToken),
-      fetchMyKnowledgeSubmissions(),
-    ])
+    Promise.allSettled([getMyPage(accessToken), fetchMyKnowledgeSubmissions()])
       .then(([myPageResult, submissionsResult]) => {
         if (myPageResult.status === "fulfilled") {
-          const myPage = myPageResult.value;
-          console.log("[ProfilePage] mypage:", myPage);
-          setBalance(myPage.hsTokenBalance);
-          setEmail(myPage.email);
-          setWalletAddress(myPage.walletAddress);
+          const p = myPageResult.value;
+          console.log("[ProfilePage] mypage:", p);
+          setBalance(p.hsTokenBalance);
+          setEmail(p.email);
+          setWalletAddress(p.walletAddress);
           setOwnedNfts(
-            myPage.nfts.map((n) => ({
-              ...n,
-              isSold: true,
-              owner: myPage.walletAddress,
-              txHash: n.txHash ?? null,
-            })),
+            p.nfts.map((n) => ({ ...n, isSold: true, owner: p.walletAddress, txHash: n.txHash ?? null })),
           );
         } else {
           console.warn("[ProfilePage] mypage fetch failed:", myPageResult.reason);
-          setOwnedNfts([]);
         }
 
         if (submissionsResult.status === "fulfilled") {
           console.log("[ProfilePage] submissions:", submissionsResult.value);
-          setSubmissionStats(countCreateSubmissionStats(submissionsResult.value));
+          setDailyQStats(countCreateSubmissionStats(submissionsResult.value));
         } else {
           console.warn("[ProfilePage] submissions fetch failed:", submissionsResult.reason);
-          setSubmissionStats(defaultDailyQStats);
         }
       })
-      .catch(() => {
-        setOwnedNfts([]);
-        setSubmissionStats(defaultDailyQStats);
-      })
-      .finally(() => {
-        setLoading(false);
-      });
+      .finally(() => setLoading(false));
   }, [accessToken]);
 
-  const profile = useMemo(
-    () => ({
-      name: tempUser?.name ?? "",
-      email: email || tempUser?.email || "",
-      walletAddress: walletAddress || tempUser?.walletAddress || "",
-      dailyQ: submissionStats,
-    }),
-    [email, walletAddress, submissionStats, tempUser],
-  );
-
-  const myBuildings = ownedNfts.length > 0 ? ownedNfts : [];
-
-  const initials = profile.name
-    .split(" ")
-    .map((word) => word[0])
-    .join("")
-    .slice(0, 2)
-    .toUpperCase();
+  const handleLogout = () => {
+    clearAuthTokens();
+    navigate("/auth/login", { replace: true });
+  };
 
   return (
     <div className={`relative min-h-full bg-[#f3f3f3] px-4 pb-6 ${SIDEBAR_BUTTON_SAFE_TOP_CLASS}`}>
-      
-      <section className="mt-6">
-        <div className="flex items-center gap-4">
-          <div className="flex h-20 w-20 items-center justify-center rounded-full border-[0.5px] border-[#A8A29F] bg-[#D6D3D1] text-[34px] font-bold text-[#A8A29F]">
-            {initials}
-          </div>
+      <ProfileHeader
+        name={tempUser?.name ?? ""}
+        email={email || tempUser?.email || ""}
+        balance={balance}
+        buildingCount={ownedNfts.length}
+      />
 
-          <div>
-            <h1 className="text-[28px] font-semibold leading-none text-[#002A47]">{profile.name}</h1>
-            <p className="mt-2 text-[14px] text-[#A8A29F]">{profile.email}</p>
-          </div>
-        </div>
-
-        <div className="mt-6 grid grid-cols-2 gap-2">
-          <div className="rounded-xl border border-[#c9c9c9] bg-[#f4f4f4] px-3 py-3 text-center">
-            <p className="text-[24px] font-semibold leading-none text-[#002A47]">{balance}</p>
-            <p className="mt-1 text-[12px] text-[#78716D]">Tokens Balance</p>
-          </div>
-          <div className="rounded-xl border border-[#c9c9c9] bg-[#f4f4f4] px-3 py-3 text-center">
-            <p className="text-[24px] font-semibold leading-none text-[#002A47]">{myBuildings.length}</p>
-            <p className="mt-1 text-[12px] text-[#78716D]">My Buildings</p>
-          </div>
-        </div>
-      </section>
-
-      <section className="mt-6 border-t border-[#dfdfdf] pt-4">
-        <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-[12px] font-bold tracking-wide text-[#78716D]">DAILY Q HISTORY</h2>
-          <button
-            type="button"
-            onClick={() => navigate("/daily-q/history")}
-            className="text-[12px] font-medium text-[#10314f]"
-          >
-            View History →
-          </button>
-        </div>
-
-        <div className="flex rounded-xl border border-[#c9c9c9] bg-[#f4f4f4]">
-          <div className="flex-1 py-3 text-center">
-            <p className="text-[24px] font-bold leading-none text-[#2D7A2D]">{profile.dailyQ.received}</p>
-            <p className="mt-1 text-[12px] text-[#2D7A2D]">Received</p>
-          </div>
-          <div className="my-3 w-px bg-[#d5d5d5]" />
-          <div className="flex-1 py-3 text-center">
-            <p className="text-[24px] font-bold leading-none text-[#B35900]">{profile.dailyQ.pending}</p>
-            <p className="mt-1 text-[12px] text-[#B35900]">Pending</p>
-          </div>
-          <div className="my-3 w-px bg-[#d5d5d5]" />
-          <div className="flex-1 py-3 text-center">
-            <p className="text-[24px] font-bold leading-none text-[#C0392B]">{profile.dailyQ.notCredited}</p>
-            <p className="mt-1 text-[12px] text-[#C0392B]">Not Credited</p>
-          </div>
-        </div>
-      </section>
+      <DailyQStatsSection stats={dailyQStats} />
 
       <section className="mt-6 border-t border-[#dfdfdf] pt-4">
         <NftGridSection
           title="MY BUILDINGS"
-          items={myBuildings.filter((g) => g.isSold)}
+          items={ownedNfts}
           onItemClick={setSelectedItem}
           badgeText="Owned"
           emptyMessage="소유한 건물이 없습니다."
@@ -179,62 +94,14 @@ export default function ProfilePage() {
         closeLabel="profile"
       />
 
-      <section className="mt-6 border-t border-[#dfdfdf] pt-4">
-        <h2 className="mb-3 text-[12px] font-bold tracking-wide text-[#78716D]">ACCOUNT</h2>
-        <div className="overflow-hidden rounded-xl border border-[#A8A29F] bg-[#f4f4f4]">
-          <div className="grid grid-cols-[120px_1fr] border-[0.5px] border-[#d7d7d7] px-4 py-3 text-[14px]">
-            <p className="font-medium text-[#002A47]">Email</p>
-            <p className="truncate text-right text-[#78716D]">{profile.email}</p>
-          </div>
-          <div className="grid grid-cols-[120px_1fr] border-b border-[#D6D3D1] px-4 py-3 text-[14px]">
-            <p className="font-medium text-[#002A47]">Wallet</p>
-            <p className="truncate text-right text-[#78716D]">{profile.walletAddress}</p>
-          </div>
-        </div>
+      <AccountSection
+        email={email || tempUser?.email || ""}
+        walletAddress={walletAddress || tempUser?.walletAddress || ""}
+        onLogout={() => setShowLogoutModal(true)}
+      />
 
-        <button
-          type="button"
-          onClick={() => setShowLogoutModal(true)}
-          className="mt-4 w-full rounded-xl border border-[#C0392B] py-3 text-[14px] font-medium text-[#C0392B] active:bg-rose-50"
-        >
-          로그아웃
-        </button>
-      </section>
-
-      {/* 로그아웃 확인 모달 */}
       {showLogoutModal && (
-        <div className="fixed inset-0 z-[100] flex items-end justify-center">
-          {/* Backdrop */}
-          <div
-            className="absolute inset-0 bg-black/40"
-            onClick={() => setShowLogoutModal(false)}
-          />
-          <div className="relative w-full max-w-[430px] rounded-t-3xl bg-white px-5 pt-6 pb-10 shadow-xl">
-            <div className="mb-4 text-center">
-              <p className="text-[17px] font-semibold text-[#002A47]">로그아웃 하시겠어요?</p>
-              <p className="mt-1.5 text-[13px] text-[#78716D]">로그인 페이지로 이동합니다.</p>
-            </div>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={() => setShowLogoutModal(false)}
-                className="flex-1 rounded-xl border border-[#D6D3D1] bg-[#f4f4f4] py-3 text-[14px] font-medium text-[#44403D]"
-              >
-                취소
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  clearAuthTokens();
-                  navigate("/auth/login", { replace: true });
-                }}
-                className="flex-1 rounded-xl bg-[#C0392B] py-3 text-[14px] font-medium text-white"
-              >
-                로그아웃
-              </button>
-            </div>
-          </div>
-        </div>
+        <LogoutModal onCancel={() => setShowLogoutModal(false)} onConfirm={handleLogout} />
       )}
     </div>
   );

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -5,25 +5,31 @@ import {
   getNftGoods,
   type NftGoodsItem,
 } from "../../apis/blockchain/blockchain";
-import { fetchMySubmissions } from "../../apis/knowledge/knowledge";
+import { fetchMyKnowledgeSubmissions } from "../../apis/knowledge/knowledge";
 import { useAuthStore } from "../../store/useAuthStore";
 import { SIDEBAR_BUTTON_SAFE_TOP_CLASS } from "../../utils/layout";
 import NftGridSection from "../../components/shop/NftGridSection";
 import BuildingDetailModal from "../../components/map/BuildingDetailModal";
-import { fetchMyKnowledgeSubmissions } from "../../apis/knowledge/knowledge";
 import { countCreateSubmissionStats } from "../../features/knowledge/knowledgeSubmissionStats";
 
-type ProfileDailyQData = {
+type ProfileDailyQStats = {
+  received: number;
+  pending: number;
+  notCredited: number;
+};
+
+type ProfileMockData = {
   walletType: string;
 };
 
-const defaultDailyQ: ProfileDailyQData = {
+const profileMock: ProfileMockData = {
   walletType: "MetaMask",
-  dailyQ: {
-    received: 0,
-    pending: 0,
-    notCredited: 0,
-  },
+};
+
+const defaultDailyQStats: ProfileDailyQStats = {
+  received: 0,
+  pending: 0,
+  notCredited: 0,
 };
 
 
@@ -34,7 +40,8 @@ export default function ProfilePage() {
   const [balance, setBalance] = useState("12");
   const [ownedNfts, setOwnedNfts] = useState<NftGoodsItem[]>([]);
   const [selectedItem, setSelectedItem] = useState<NftGoodsItem | null>(null);
-  const [dailyQStats, setDailyQStats] = useState(defaultDailyQ.dailyQ);
+  const [loading, setLoading] = useState(true);
+  const [submissionStats, setSubmissionStats] = useState<ProfileDailyQStats>(defaultDailyQStats);
 
   const accessToken = localStorage.getItem("accessToken") ?? undefined;
 
@@ -43,7 +50,7 @@ export default function ProfilePage() {
     Promise.allSettled([
       getHsBalance(accessToken),
       getNftGoods(accessToken),
-      fetchMySubmissions(),
+      fetchMyKnowledgeSubmissions(),
     ])
       .then(([balanceResult, goodsResult, submissionsResult]) => {
         if (balanceResult.status === "fulfilled") {
@@ -63,39 +70,30 @@ export default function ProfilePage() {
 
         if (submissionsResult.status === "fulfilled") {
           console.log("[ProfilePage] submissions:", submissionsResult.value);
-          const received = submissionsResult.value.filter((item) => item.status === "APPROVED").length;
-          const pending = submissionsResult.value.filter((item) => item.status === "PENDING").length;
-          const notCredited = submissionsResult.value.filter((item) => item.status === "REJECTED").length;
-          setSubmissionStats({ received, pending, notCredited });
+          setSubmissionStats(countCreateSubmissionStats(submissionsResult.value));
         } else {
           console.warn("[ProfilePage] submissions fetch failed:", submissionsResult.reason);
-          setSubmissionStats({ received: 0, pending: 0, notCredited: 0 });
+          setSubmissionStats(defaultDailyQStats);
         }
       })
       .catch(() => {
         setOwnedNfts([]);
-        setSubmissionStats({ received: 0, pending: 0, notCredited: 0 });
+        setSubmissionStats(defaultDailyQStats);
       })
       .finally(() => {
         setLoading(false);
       });
   }, [accessToken]);
 
-  useEffect(() => {
-    fetchMyKnowledgeSubmissions()
-      .then((items) => setDailyQStats(countCreateSubmissionStats(items)))
-      .catch(() => setDailyQStats(defaultDailyQ.dailyQ));
-  }, []);
-
   const profile = useMemo(
     () => ({
       name: tempUser?.name || "Sean Kim",
       email: tempUser?.email || "sean@university.edu",
       walletAddress: tempUser?.walletAddress || "0x4a3b...f3b1",
-      walletType: defaultDailyQ.walletType,
-      dailyQ: dailyQStats,
+      walletType: profileMock.walletType,
+      dailyQ: submissionStats,
     }),
-    [dailyQStats, tempUser],
+    [submissionStats, tempUser],
   );
 
   const myBuildings = ownedNfts.length > 0 ? ownedNfts : [];
@@ -137,23 +135,28 @@ export default function ProfilePage() {
       <section className="mt-6 border-t border-[#dfdfdf] pt-4">
         <div className="mb-3 flex items-center justify-between">
           <h2 className="text-[12px] font-bold tracking-wide text-[#78716D]">DAILY Q HISTORY</h2>
-          {/* daily q history로 이동 */}
-          <button type="button" onClick={() => navigate("/daily-q")} className="text-xl font-semibold text-[#10314f]">View History →</button>
+          <button
+            type="button"
+            onClick={() => navigate("/daily-q/history")}
+            className="text-[12px] font-medium text-[#10314f]"
+          >
+            View History →
+          </button>
         </div>
 
         <div className="flex rounded-xl border border-[#c9c9c9] bg-[#f4f4f4]">
           <div className="flex-1 py-3 text-center">
-            <p className="text-[24px] font-bold leading-none text-[#2D7A2D]">{submissionStats.received}</p>
+            <p className="text-[24px] font-bold leading-none text-[#2D7A2D]">{profile.dailyQ.received}</p>
             <p className="mt-1 text-[12px] text-[#2D7A2D]">Received</p>
           </div>
           <div className="my-3 w-px bg-[#d5d5d5]" />
           <div className="flex-1 py-3 text-center">
-            <p className="text-[24px] font-bold leading-none text-[#B35900]">{submissionStats.pending}</p>
+            <p className="text-[24px] font-bold leading-none text-[#B35900]">{profile.dailyQ.pending}</p>
             <p className="mt-1 text-[12px] text-[#B35900]">Pending</p>
           </div>
           <div className="my-3 w-px bg-[#d5d5d5]" />
           <div className="flex-1 py-3 text-center">
-            <p className="text-[24px] font-bold leading-none text-[#C0392B]">{submissionStats.notCredited}</p>
+            <p className="text-[24px] font-bold leading-none text-[#C0392B]">{profile.dailyQ.notCredited}</p>
             <p className="mt-1 text-[12px] text-[#C0392B]">Not Credited</p>
           </div>
         </div>

--- a/src/pages/profile/ProfilePage.tsx
+++ b/src/pages/profile/ProfilePage.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
-  getHsBalance,
-  getNftGoods,
+  getMyPage,
   type NftGoodsItem,
 } from "../../apis/blockchain/blockchain";
 import { fetchMyKnowledgeSubmissions } from "../../apis/knowledge/knowledge";
+import { clearAuthTokens } from "../../apis/auth/auth";
 import { useAuthStore } from "../../store/useAuthStore";
 import { SIDEBAR_BUTTON_SAFE_TOP_CLASS } from "../../utils/layout";
 import NftGridSection from "../../components/shop/NftGridSection";
@@ -16,14 +16,6 @@ type ProfileDailyQStats = {
   received: number;
   pending: number;
   notCredited: number;
-};
-
-type ProfileMockData = {
-  walletType: string;
-};
-
-const profileMock: ProfileMockData = {
-  walletType: "MetaMask",
 };
 
 const defaultDailyQStats: ProfileDailyQStats = {
@@ -37,9 +29,12 @@ const defaultDailyQStats: ProfileDailyQStats = {
 export default function ProfilePage() {
   const navigate = useNavigate();
   const tempUser = useAuthStore((state) => state.tempUser);
-  const [balance, setBalance] = useState("12");
+  const [balance, setBalance] = useState("");
+  const [email, setEmail] = useState("");
+  const [walletAddress, setWalletAddress] = useState("");
   const [ownedNfts, setOwnedNfts] = useState<NftGoodsItem[]>([]);
   const [selectedItem, setSelectedItem] = useState<NftGoodsItem | null>(null);
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
   const [loading, setLoading] = useState(true);
   const [submissionStats, setSubmissionStats] = useState<ProfileDailyQStats>(defaultDailyQStats);
 
@@ -48,23 +43,26 @@ export default function ProfilePage() {
   useEffect(() => {
     setLoading(true);
     Promise.allSettled([
-      getHsBalance(accessToken),
-      getNftGoods(accessToken),
+      getMyPage(accessToken),
       fetchMyKnowledgeSubmissions(),
     ])
-      .then(([balanceResult, goodsResult, submissionsResult]) => {
-        if (balanceResult.status === "fulfilled") {
-          console.log("[ProfilePage] balance:", balanceResult.value);
-          setBalance(balanceResult.value.balance);
+      .then(([myPageResult, submissionsResult]) => {
+        if (myPageResult.status === "fulfilled") {
+          const myPage = myPageResult.value;
+          console.log("[ProfilePage] mypage:", myPage);
+          setBalance(myPage.hsTokenBalance);
+          setEmail(myPage.email);
+          setWalletAddress(myPage.walletAddress);
+          setOwnedNfts(
+            myPage.nfts.map((n) => ({
+              ...n,
+              isSold: true,
+              owner: myPage.walletAddress,
+              txHash: n.txHash ?? null,
+            })),
+          );
         } else {
-          console.warn("[ProfilePage] balance fetch failed:", balanceResult.reason);
-        }
-
-        if (goodsResult.status === "fulfilled") {
-          console.log("[ProfilePage] nftGoods:", goodsResult.value);
-          setOwnedNfts(goodsResult.value.filter((item) => item.isSold));
-        } else {
-          console.warn("[ProfilePage] nftGoods fetch failed:", goodsResult.reason);
+          console.warn("[ProfilePage] mypage fetch failed:", myPageResult.reason);
           setOwnedNfts([]);
         }
 
@@ -87,13 +85,12 @@ export default function ProfilePage() {
 
   const profile = useMemo(
     () => ({
-      name: tempUser?.name || "Sean Kim",
-      email: tempUser?.email || "sean@university.edu",
-      walletAddress: tempUser?.walletAddress || "0x4a3b...f3b1",
-      walletType: profileMock.walletType,
+      name: tempUser?.name ?? "",
+      email: email || tempUser?.email || "",
+      walletAddress: walletAddress || tempUser?.walletAddress || "",
       dailyQ: submissionStats,
     }),
-    [submissionStats, tempUser],
+    [email, walletAddress, submissionStats, tempUser],
   );
 
   const myBuildings = ownedNfts.length > 0 ? ownedNfts : [];
@@ -193,12 +190,52 @@ export default function ProfilePage() {
             <p className="font-medium text-[#002A47]">Wallet</p>
             <p className="truncate text-right text-[#78716D]">{profile.walletAddress}</p>
           </div>
-          <div className="grid grid-cols-[120px_1fr] border-b border-[#D6D3D1] px-4 py-3 text-[14px]">
-            <p className="font-medium text-[#002A47]">Wallet Type</p>
-            <p className="truncate text-right text-[#78716D]">{profile.walletType}</p>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setShowLogoutModal(true)}
+          className="mt-4 w-full rounded-xl border border-[#C0392B] py-3 text-[14px] font-medium text-[#C0392B] active:bg-rose-50"
+        >
+          로그아웃
+        </button>
+      </section>
+
+      {/* 로그아웃 확인 모달 */}
+      {showLogoutModal && (
+        <div className="fixed inset-0 z-[100] flex items-end justify-center">
+          {/* Backdrop */}
+          <div
+            className="absolute inset-0 bg-black/40"
+            onClick={() => setShowLogoutModal(false)}
+          />
+          <div className="relative w-full max-w-[430px] rounded-t-3xl bg-white px-5 pt-6 pb-10 shadow-xl">
+            <div className="mb-4 text-center">
+              <p className="text-[17px] font-semibold text-[#002A47]">로그아웃 하시겠어요?</p>
+              <p className="mt-1.5 text-[13px] text-[#78716D]">로그인 페이지로 이동합니다.</p>
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setShowLogoutModal(false)}
+                className="flex-1 rounded-xl border border-[#D6D3D1] bg-[#f4f4f4] py-3 text-[14px] font-medium text-[#44403D]"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  clearAuthTokens();
+                  navigate("/auth/login", { replace: true });
+                }}
+                className="flex-1 rounded-xl bg-[#C0392B] py-3 text-[14px] font-medium text-white"
+              >
+                로그아웃
+              </button>
+            </div>
           </div>
         </div>
-      </section>
+      )}
     </div>
   );
 }

--- a/src/pages/profile/components/AccountSection.tsx
+++ b/src/pages/profile/components/AccountSection.tsx
@@ -1,0 +1,47 @@
+type Props = {
+  email: string;
+  walletAddress: string;
+  onLogout: () => void;
+};
+
+export default function AccountSection({ email, walletAddress, onLogout }: Props) {
+  return (
+    <section className="mt-6 border-t border-[#dfdfdf] pt-4">
+      <h2 className="mb-3 text-[12px] font-bold tracking-wide text-[#78716D]">ACCOUNT</h2>
+
+      <div className="overflow-hidden rounded-xl border border-[#A8A29F] bg-[#f4f4f4]">
+        <InfoRow label="Email" value={email} topBorder />
+        <InfoRow label="Wallet" value={walletAddress} />
+      </div>
+
+      <button
+        type="button"
+        onClick={onLogout}
+        className="mt-4 w-full rounded-xl border border-[#C0392B] py-3 text-[14px] font-medium text-[#C0392B] active:bg-rose-50"
+      >
+        로그아웃
+      </button>
+    </section>
+  );
+}
+
+function InfoRow({
+  label,
+  value,
+  topBorder,
+}: {
+  label: string;
+  value: string;
+  topBorder?: boolean;
+}) {
+  return (
+    <div
+      className={`grid grid-cols-[120px_1fr] px-4 py-3 text-[14px] ${
+        topBorder ? "border-[0.5px] border-[#d7d7d7]" : "border-b border-[#D6D3D1]"
+      }`}
+    >
+      <p className="font-medium text-[#002A47]">{label}</p>
+      <p className="truncate text-right text-[#78716D]">{value}</p>
+    </div>
+  );
+}

--- a/src/pages/profile/components/DailyQStatsSection.tsx
+++ b/src/pages/profile/components/DailyQStatsSection.tsx
@@ -1,0 +1,51 @@
+import { useNavigate } from "react-router-dom";
+
+type DailyQStats = {
+  received: number;
+  pending: number;
+  notCredited: number;
+};
+
+type Props = {
+  stats: DailyQStats;
+};
+
+export default function DailyQStatsSection({ stats }: Props) {
+  const navigate = useNavigate();
+
+  return (
+    <section className="mt-6 border-t border-[#dfdfdf] pt-4">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-[12px] font-bold tracking-wide text-[#78716D]">DAILY Q HISTORY</h2>
+        <button
+          type="button"
+          onClick={() => navigate("/daily-q/history")}
+          className="text-[12px] font-medium text-[#10314f]"
+        >
+          View History →
+        </button>
+      </div>
+
+      <div className="flex rounded-xl border border-[#c9c9c9] bg-[#f4f4f4]">
+        <StatCell value={stats.received} label="Received" color="#2D7A2D" />
+        <div className="my-3 w-px bg-[#d5d5d5]" />
+        <StatCell value={stats.pending} label="Pending" color="#B35900" />
+        <div className="my-3 w-px bg-[#d5d5d5]" />
+        <StatCell value={stats.notCredited} label="Not Credited" color="#C0392B" />
+      </div>
+    </section>
+  );
+}
+
+function StatCell({ value, label, color }: { value: number; label: string; color: string }) {
+  return (
+    <div className="flex-1 py-3 text-center">
+      <p className="text-[24px] font-bold leading-none" style={{ color }}>
+        {value}
+      </p>
+      <p className="mt-1 text-[12px]" style={{ color }}>
+        {label}
+      </p>
+    </div>
+  );
+}

--- a/src/pages/profile/components/LogoutModal.tsx
+++ b/src/pages/profile/components/LogoutModal.tsx
@@ -1,0 +1,34 @@
+type Props = {
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export default function LogoutModal({ onCancel, onConfirm }: Props) {
+  return (
+    <div className="fixed inset-0 z-[100] flex items-end justify-center">
+      <div className="absolute inset-0 bg-black/40" onClick={onCancel} />
+      <div className="relative w-full max-w-[430px] rounded-t-3xl bg-white px-5 pt-6 pb-10 shadow-xl">
+        <div className="mb-4 text-center">
+          <p className="text-[17px] font-semibold text-[#002A47]">로그아웃 하시겠어요?</p>
+          <p className="mt-1.5 text-[13px] text-[#78716D]">로그인 페이지로 이동합니다.</p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 rounded-xl border border-[#D6D3D1] bg-[#f4f4f4] py-3 text-[14px] font-medium text-[#44403D]"
+          >
+            취소
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="flex-1 rounded-xl bg-[#C0392B] py-3 text-[14px] font-medium text-white"
+          >
+            로그아웃
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/profile/components/ProfileHeader.tsx
+++ b/src/pages/profile/components/ProfileHeader.tsx
@@ -1,0 +1,40 @@
+type Props = {
+  name: string;
+  email: string;
+  balance: string;
+  buildingCount: number;
+};
+
+export default function ProfileHeader({ name, email, balance, buildingCount }: Props) {
+  const initials = name
+    .split(" ")
+    .map((w) => w[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <section className="mt-6">
+      <div className="flex items-center gap-4">
+        <div className="flex h-20 w-20 items-center justify-center rounded-full border-[0.5px] border-[#A8A29F] bg-[#D6D3D1] text-[34px] font-bold text-[#A8A29F]">
+          {initials}
+        </div>
+        <div>
+          <h1 className="text-[28px] font-semibold leading-none text-[#002A47]">{name}</h1>
+          <p className="mt-2 text-[14px] text-[#A8A29F]">{email}</p>
+        </div>
+      </div>
+
+      <div className="mt-6 grid grid-cols-2 gap-2">
+        <div className="rounded-xl border border-[#c9c9c9] bg-[#f4f4f4] px-3 py-3 text-center">
+          <p className="text-[24px] font-semibold leading-none text-[#002A47]">{balance}</p>
+          <p className="mt-1 text-[12px] text-[#78716D]">Tokens Balance</p>
+        </div>
+        <div className="rounded-xl border border-[#c9c9c9] bg-[#f4f4f4] px-3 py-3 text-center">
+          <p className="text-[24px] font-semibold leading-none text-[#002A47]">{buildingCount}</p>
+          <p className="mt-1 text-[12px] text-[#78716D]">My Buildings</p>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION

### 변경 내용
- **마이페이지 API 연동**
  - `/users/mypage` 응답 기반으로 프로필 정보(이메일/지갑/토큰/보유 NFT) 조회하도록 통합
  - 기존 분산 호출 로직 일부를 단일 응답 기준으로 정리

- **Profile 페이지 구조 개선 (리팩토링)**
  - 페이지 길이와 복잡도 완화를 위해 섹션 단위 컴포넌트로 분리
  - 헤더/통계/계정/로그아웃 모달 등 UI 책임 분리로 가독성 및 유지보수성 개선

- **Daily Q 영역 정리**
  - 프로필 내 Daily Q 통계 데이터 연동 정리
  - 히스토리 이동 동선 정리(중복 흐름 제거 후 히스토리 페이지 중심으로 연결)

- **인증 처리 개선**
  - 토큰 존재 여부만 보지 않고 JWT `exp` 기준 만료 검증 추가
  - 만료 토큰으로 인한 잘못된 로그인 상태 진입 이슈 보완

- **로그아웃 UX 개선**
  - 로그아웃 버튼 추가
  - 확인용 바텀시트 모달 추가(취소/확인 동작 분리)

### 참고 사항
- 현재 블록체인 연동 일부는 백엔드 상태에 따라 mock/실데이터 혼용 가능성이 있어 추가 점검 예정

### 진행 상태
> **WIP (작업 진행 중)**  
> 점검 후 최종 정리해서 머지 예정입니다.
