### PR TITLE
fix: 구매 모달 UI/상세 정보 및 닫기 동작 개선

### DIFF
--- a/src/apis/blockchain/blockchain.ts
+++ b/src/apis/blockchain/blockchain.ts
@@ -11,7 +11,22 @@ export interface NftGoodsItem {
   isSold: boolean;
   txHash: string | null;
   owner: string | null;
+  ownerName?: string | null;
 }
+
+type RawNftGoodsOwner =
+  | string
+  | null
+  | {
+      name?: string | null;
+      walletAddress?: string | null;
+      [key: string]: unknown;
+    };
+
+type RawNftGoodsItem = Omit<NftGoodsItem, "owner" | "txHash"> & {
+  owner: RawNftGoodsOwner;
+  txHash: string | null;
+};
 
 export interface PurchaseNftRequest {
   index: number;
@@ -63,6 +78,34 @@ const createAuthConfig = (accessToken?: string) => {
     },
   };
 };
+
+const normalizeOwnerAddress = (owner: RawNftGoodsOwner): string | null => {
+  if (typeof owner === "string") return owner;
+  if (owner && typeof owner === "object" && typeof owner.walletAddress === "string") {
+    return owner.walletAddress;
+  }
+  return null;
+};
+
+const normalizeOwnerName = (owner: RawNftGoodsOwner): string | null => {
+  if (owner && typeof owner === "object" && typeof owner.name === "string") {
+    return owner.name;
+  }
+  return null;
+};
+
+const normalizeNftGoodsItem = (item: RawNftGoodsItem): NftGoodsItem => ({
+  index: item.index,
+  name: item.name,
+  description: item.description,
+  price: item.price,
+  imageUrl: item.imageUrl,
+  metadataUrl: item.metadataUrl,
+  isSold: item.isSold,
+  txHash: item.txHash ?? null,
+  owner: normalizeOwnerAddress(item.owner),
+  ownerName: normalizeOwnerName(item.owner),
+});
 
 export const ensureNftPurchaseApproval = async (
   requiredAmount: string | number,
@@ -131,6 +174,7 @@ const MOCK_NFT_GOODS: NftGoodsItem[] = [
     isSold: true,
     txHash: "0xabcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
     owner: "0xABCD...1234",
+    ownerName: "홍길동",
   },
   {
     index: 2,
@@ -265,11 +309,11 @@ export const getNftGoods = async (accessToken?: string): Promise<NftGoodsItem[]>
   if (USE_MOCK) {
     return new Promise((resolve) => setTimeout(() => resolve(MOCK_NFT_GOODS), 300));
   }
-  const { data } = await axiosInstance.get<NftGoodsItem[]>(
+  const { data } = await axiosInstance.get<RawNftGoodsItem[]>(
     "/blockchain/nft/goods",
     createAuthConfig(accessToken),
   );
-  return data;
+  return Array.isArray(data) ? data.map(normalizeNftGoodsItem) : [];
 };
 
 export const purchaseNft = async (

--- a/src/components/chat/Sidebar.tsx
+++ b/src/components/chat/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { NavLink } from "react-router-dom";
 import logoUrl from "../../assets/logo.svg";
 
@@ -22,6 +23,17 @@ const menuSections = [
 ] as const;
 
 export default function HomeSidebar({ open, onClose }: Props) {
+  const asideRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (open) return;
+
+    const active = document.activeElement;
+    if (active instanceof HTMLElement && asideRef.current?.contains(active)) {
+      active.blur();
+    }
+  }, [open]);
+
   return (
     <>
       <div
@@ -30,6 +42,7 @@ export default function HomeSidebar({ open, onClose }: Props) {
         aria-hidden={!open}
       />
       <aside
+        ref={asideRef}
         className={`absolute left-0 top-0 z-[92] h-full w-[86vw] max-w-[340px] bg-[#F5F5F5] px-6 py-8 shadow-xl transition-transform duration-300 ${open ? "translate-x-0" : "-translate-x-full"}`}
         aria-hidden={!open}
       >

--- a/src/components/common/AnimatedBottomSheet.tsx
+++ b/src/components/common/AnimatedBottomSheet.tsx
@@ -83,13 +83,12 @@ export default function AnimatedBottomSheet({
       />
 
       <div
-        className={`fixed inset-0 z-[80] flex items-end justify-center transition-all duration-300 ${
+        className={`pointer-events-none fixed inset-0 z-[80] flex items-end justify-center transition-all duration-300 ${
           visible ? "opacity-100" : "opacity-0"
         }`}
-        onClick={(event) => event.stopPropagation()}
       >
         <div
-          className={`w-full max-w-[430px] transition-transform duration-300 ${
+          className={`pointer-events-auto w-full max-w-[430px] transition-transform duration-300 ${
             visible ? "translate-y-0" : "translate-y-8"
           }`}
         >

--- a/src/components/common/AnimatedBottomSheet.tsx
+++ b/src/components/common/AnimatedBottomSheet.tsx
@@ -83,12 +83,18 @@ export default function AnimatedBottomSheet({
       />
 
       <div
-        className={`fixed inset-x-0 bottom-0 z-[80] transition-all duration-300 ${
-          visible ? "translate-y-0 opacity-100" : "translate-y-8 opacity-0"
+        className={`fixed inset-0 z-[80] flex items-end justify-center transition-all duration-300 ${
+          visible ? "opacity-100" : "opacity-0"
         }`}
         onClick={(event) => event.stopPropagation()}
       >
-        {children}
+        <div
+          className={`w-full max-w-[430px] transition-transform duration-300 ${
+            visible ? "translate-y-0" : "translate-y-8"
+          }`}
+        >
+          {children}
+        </div>
       </div>
     </>
   );

--- a/src/components/map/BuildingDetailModal.tsx
+++ b/src/components/map/BuildingDetailModal.tsx
@@ -68,7 +68,7 @@ export default function BuildingDetailModal({
           <BalancePill balance={balance} className="mb-2 ml-auto mr-4" />
         )}
 
-        <div className="max-h-[75vh] min-h-[62vh] overflow-y-auto rounded-t-3xl bg-[#F5F5F4] p-5 shadow-[0_-8px_24px_rgba(0,0,0,0.18)]">
+        <div className="max-h-[75vh] overflow-y-auto rounded-t-3xl bg-[#F5F5F4] p-5 shadow-[0_-8px_24px_rgba(0,0,0,0.18)]">
           <span
             className="inline-flex rounded-full border border-[#A8A29F] bg-[#F5F5F4] px-2.5 py-0.5 text-[10px] font-medium text-[#44403D]"
           >

--- a/src/components/map/BuildingDetailModal.tsx
+++ b/src/components/map/BuildingDetailModal.tsx
@@ -14,10 +14,19 @@ type BuildingDetailModalProps = {
   closeLabel?: string;
 };
 
-const formatShort = (value: string | null | undefined, fallback = "-") => {
-  if (!value) return fallback;
-  if (value.length <= 14) return value;
-  return `${value.slice(0, 6)}...${value.slice(-4)}`;
+const formatShort = (value: unknown, fallback = "-") => {
+  if (value === null || value === undefined) return fallback;
+
+  const text =
+    typeof value === "string"
+      ? value
+      : typeof value === "number" || typeof value === "bigint" || typeof value === "boolean"
+        ? String(value)
+        : null;
+
+  if (!text) return fallback;
+  if (text.length <= 14) return text;
+  return `${text.slice(0, 6)}...${text.slice(-4)}`;
 };
 
 export default function BuildingDetailModal({
@@ -49,8 +58,8 @@ export default function BuildingDetailModal({
   if (!currentItem && !open) return null;
 
   const isSold = currentItem?.isSold ?? false;
-  const owner = isSold ? currentItem?.owner ?? null : null;
-  const txHash = isSold ? currentItem?.txHash ?? null : null;
+  const productHash = isSold ? currentItem?.txHash ?? null : null;
+  const ownerHash = isSold ? currentItem?.owner ?? null : null;
   const numericBalance = Number(balance);
   const numericPrice = Number(currentItem?.price ?? 0);
   const isInsufficientBalance =
@@ -84,16 +93,20 @@ export default function BuildingDetailModal({
 
           <dl className="mt-6 space-y-2 text-[12px] text-slate-700">
             <div className="grid grid-cols-[110px_1fr] gap-2">
+              <dt className="text-slate-500">Hash</dt>
+              <dd className="truncate">{formatShort(currentItem?.txHash)}</dd>
+            </div>
+            <div className="grid grid-cols-[110px_1fr] gap-2">
               <dt className="text-slate-500">Metadata</dt>
               <dd className="truncate">{formatShort(currentItem?.metadataUrl)}</dd>
             </div>
             <div className="grid grid-cols-[110px_1fr] gap-2">
               <dt className="text-slate-500">Owner</dt>
-              <dd>{formatShort(owner, "-")}</dd>
+              <dd>{formatShort(currentItem?.name, "-")}</dd>
             </div>
             <div className="grid grid-cols-[110px_1fr] gap-2">
-              <dt className="text-slate-500">Tx Hash</dt>
-              <dd>{formatShort(txHash, "-")}</dd>
+              <dt className="text-slate-500">Owner Hash</dt>
+              <dd>{formatShort(ownerHash, "-")}</dd>
             </div>
           </dl>
 

--- a/src/components/map/BuildingDetailModal.tsx
+++ b/src/components/map/BuildingDetailModal.tsx
@@ -59,6 +59,7 @@ export default function BuildingDetailModal({
 
   const isSold = currentItem?.isSold ?? false;
   const productHash = isSold ? currentItem?.txHash ?? null : null;
+  const ownerName = isSold ? currentItem?.ownerName ?? null : null;
   const ownerHash = isSold ? currentItem?.owner ?? null : null;
   const numericBalance = Number(balance);
   const numericPrice = Number(currentItem?.price ?? 0);
@@ -94,7 +95,7 @@ export default function BuildingDetailModal({
           <dl className="mt-6 space-y-2 text-[12px] text-slate-700">
             <div className="grid grid-cols-[110px_1fr] gap-2">
               <dt className="text-slate-500">Hash</dt>
-              <dd className="truncate">{formatShort(currentItem?.txHash)}</dd>
+              <dd className="truncate">{formatShort(productHash)}</dd>
             </div>
             <div className="grid grid-cols-[110px_1fr] gap-2">
               <dt className="text-slate-500">Metadata</dt>
@@ -102,7 +103,7 @@ export default function BuildingDetailModal({
             </div>
             <div className="grid grid-cols-[110px_1fr] gap-2">
               <dt className="text-slate-500">Owner</dt>
-              <dd>{formatShort(currentItem?.name, "-")}</dd>
+              <dd>{formatShort(ownerName, "-")}</dd>
             </div>
             <div className="grid grid-cols-[110px_1fr] gap-2">
               <dt className="text-slate-500">Owner Hash</dt>

--- a/src/features/auth/login/ethereumErrors.ts
+++ b/src/features/auth/login/ethereumErrors.ts
@@ -23,3 +23,23 @@ export const alertEthereumFlowError = (error: unknown) => {
   }
   alert("오류가 발생했습니다. 다시 시도해주세요.");
 };
+
+export const isUserRejectedEthereumAction = (error: unknown): boolean => {
+  if (typeof error !== "object" || error === null) return false;
+
+  const walletCode = "code" in error ? (error as { code?: number | string }).code : undefined;
+  if (
+    walletCode === 4001 ||
+    walletCode === "4001" ||
+    walletCode === "ACTION_REJECTED"
+  ) {
+    return true;
+  }
+
+  const infoErrorCode =
+    "info" in error
+      ? ((error as { info?: { error?: { code?: number | string } } }).info?.error?.code ?? undefined)
+      : undefined;
+
+  return infoErrorCode === 4001 || infoErrorCode === "4001";
+};

--- a/src/pages/map/MapPage.tsx
+++ b/src/pages/map/MapPage.tsx
@@ -8,6 +8,7 @@ import {
 } from "../../apis/blockchain/blockchain";
 import BuildingDetailModal from "../../components/map/BuildingDetailModal.tsx";
 import CampusScene from "../../components/map/CampusScene.tsx";
+import { isUserRejectedEthereumAction } from "../../features/auth/login/ethereumErrors";
 
 export default function MapPage() {
   const [goods, setGoods] = useState<NftGoodsItem[]>([]);
@@ -88,13 +89,8 @@ export default function MapPage() {
       setPurchaseMessage("구매 요청이 완료되었습니다.");
       await fetchMapData();
     } catch (error) {
-      const walletCode =
-        typeof error === "object" && error !== null && "code" in error
-          ? (error as { code?: number | string }).code
-          : undefined;
-
-      if (walletCode === 4001 || walletCode === "4001") {
-        setPurchaseMessage("MetaMask 서명을 취소했습니다.");
+      if (isUserRejectedEthereumAction(error)) {
+        setPurchaseMessage("MetaMask 승인/서명을 취소했습니다. 계속하려면 구매하기를 다시 눌러주세요.");
         return;
       }
 

--- a/src/pages/shop/ShopPage.tsx
+++ b/src/pages/shop/ShopPage.tsx
@@ -10,6 +10,7 @@ import BuildingDetailModal from "../../components/map/BuildingDetailModal.tsx";
 import { AxiosError } from "axios";
 import NftGridSection from "../../components/shop/NftGridSection";
 import BalancePill from "../../components/common/BalancePill";
+import { isUserRejectedEthereumAction } from "../../features/auth/login/ethereumErrors";
 
 export default function ShopPage() {
   const [goods, setGoods] = useState<NftGoodsItem[]>([]);
@@ -56,13 +57,11 @@ export default function ShopPage() {
       setMessage({ ok: true, text: "구매 요청이 완료되었습니다." });
       await fetchShopData();
     } catch (err) {
-      const walletCode =
-        typeof err === "object" && err !== null && "code" in err
-          ? (err as { code?: number | string }).code
-          : undefined;
-
-      if (walletCode === 4001 || walletCode === "4001") {
-        setMessage({ ok: false, text: "MetaMask 서명을 취소했습니다." });
+      if (isUserRejectedEthereumAction(err)) {
+        setMessage({
+          ok: false,
+          text: "MetaMask 승인/서명을 취소했습니다. 계속하려면 구매하기를 다시 눌러 진행해주세요.",
+        });
         return;
       }
 


### PR DESCRIPTION

- 구매/컬렉션 상세 모달의 모바일 레이아웃과 하단 여백을 정리했습니다.
- 모달 외부(배경) 클릭 시 정상적으로 닫히도록 수정했습니다.
- MetaMask 사용자 거절 케이스에 대한 안내 문구를 명확하게 개선했습니다.
- NFT 응답 데이터 정규화를 통해 오너/해시 표시 오류를 수정했습니다.
- 상세 정보 영역을 Product Hash, Metadata, Name, Owner Hash 기준으로 정리했습니다.

| 구매 모달 UX와 상세 정보 표시 오류를 함께 정리한 수정입니다.