### PR TITLE
fix: 모바일 로그인 복귀 흐름 및 사이드바 활성화 보완

### DIFF
--- a/src/components/chat/Sidebar.tsx
+++ b/src/components/chat/Sidebar.tsx
@@ -66,6 +66,7 @@ export default function HomeSidebar({ open, onClose }: Props) {
                   <li key={item.label}>
                     <NavLink
                       to={item.to}
+                      end={item.to === "/campus"}
                       onClick={onClose}
                       className={({ isActive }) =>
                         `flex items-center rounded-2xl px-3 py-2.5 text-sm font-semibold text-black ${

--- a/src/features/auth/login/useWalletLogin.ts
+++ b/src/features/auth/login/useWalletLogin.ts
@@ -4,7 +4,7 @@ import { useForm } from "../../../hooks/useForm";
 import { buildPersonalSignPayload, getNonce, normalizeWalletAddress } from "../../../apis/auth/auth";
 import { alertEthereumFlowError } from "./ethereumErrors";
 import { useLoginMutation } from "./useLoginMutation";
-import { ethereumRequest } from "../wallet/ethereumProvider";
+import { connectAndSignPersonal, ethereumRequest } from "../wallet/ethereumProvider";
 
 export type LoginUiStep = "wallet" | "confirm";
 
@@ -12,7 +12,6 @@ export const useWalletLogin = () => {
   const navigate = useNavigate();
   const [step, setStep] = useState<LoginUiStep>("wallet");
   const [signingAddressRaw, setSigningAddressRaw] = useState("");
-  const [isNavigatingToConfirm, setIsNavigatingToConfirm] = useState(false);
   const { values, handleChange, setValues } = useForm({ walletAddress: "" });
   const loginMutation = useLoginMutation();
 
@@ -40,39 +39,25 @@ export const useWalletLogin = () => {
       alert("올바른 지갑 주소를 입력해주세요.");
       return;
     }
-    setIsNavigatingToConfirm(true);
-    try {
-      const accounts = await ethereumRequest<string[]>("eth_requestAccounts");
-      const raw = (accounts[0] ?? "").trim();
-      if (!raw) {
-        alert("메타마스크 계정을 찾을 수 없습니다.");
-        return;
-      }
-      const active = normalizeWalletAddress(raw);
-      if (!active) {
-        alert("메타마스크 계정을 찾을 수 없습니다. 계정 연결 후 다시 시도해주세요.");
-        return;
-      }
-      if (active !== target) {
-        alert("입력한 지갑 주소와 메타마스크 선택 계정이 다릅니다.");
-        return;
-      }
-      setSigningAddressRaw(raw);
-      setStep("confirm");
-    } catch (e) {
-      alertEthereumFlowError(e);
-    } finally {
-      setIsNavigatingToConfirm(false);
-    }
+
+    setSigningAddressRaw(target);
+    setStep("confirm");
   };
 
   const confirmLogin = async () => {
     const active = normalizeWalletAddress(signingAddressRaw);
+
+    if (!active) {
+      alert("올바른 지갑 주소를 입력해주세요.");
+      setStep("wallet");
+      return;
+    }
+
     try {
       const { nonce } = await getNonce({ walletAddress: active });
       const message = buildPersonalSignPayload(nonce);
-      const signature = await ethereumRequest<string>("personal_sign", [message, signingAddressRaw]);
-      loginMutation.mutate({ walletAddress: active, signature });
+      const { account, signature } = await connectAndSignPersonal(message, active);
+      loginMutation.mutate({ walletAddress: normalizeWalletAddress(account), signature });
     } catch (e) {
       console.error(e);
       alertEthereumFlowError(e);
@@ -88,7 +73,7 @@ export const useWalletLogin = () => {
     goToConfirm,
     confirmLogin,
     isPending: loginMutation.isPending,
-    isNavigatingToConfirm,
+    isNavigatingToConfirm: loginMutation.isPending,
     displayAddress: normalizedInput(),
     navigate,
   };

--- a/src/features/auth/wallet/ethereumProvider.ts
+++ b/src/features/auth/wallet/ethereumProvider.ts
@@ -65,6 +65,11 @@ let evmClientPromise: Promise<MetamaskConnectEVM> | null = null;
 
 const shouldUseMetaMaskConnect = () => import.meta.env.VITE_USE_METAMASK_CONNECT !== "false";
 
+const isMobileWeb = () => {
+  if (typeof navigator === "undefined") return false;
+  return /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+};
+
 const createClient = async () => {
   const { createEVMClient } = await import("@metamask/connect-evm");
 
@@ -77,8 +82,11 @@ const createClient = async () => {
       supportedNetworks: SUPPORTED_NETWORKS,
     },
     ui: {
-      preferExtension: true,
-      showInstallModal: true,
+      preferExtension: !isMobileWeb(),
+      showInstallModal: !isMobileWeb(),
+    },
+    mobile: {
+      useDeeplink: true,
     },
   });
 };
@@ -176,4 +184,48 @@ export const ethereumRequest = async <T = unknown>(
     : await getEthereumProvider();
 
   return (await provider.request({ method, params })) as T;
+};
+
+export const connectAndSignPersonal = async (
+  message: string,
+  expectedAddress?: string,
+): Promise<{ account: string; signature: string }> => {
+  const client = await getMetaMaskConnectClient();
+
+  if (client) {
+    const { accounts, signature } = await client.connectAndSign({
+      message,
+      chainIds: [DEFAULT_CHAIN_HEX],
+    });
+
+    const account = String(accounts[0] ?? "").trim();
+    if (!account) {
+      throw new Error("메타마스크 계정을 찾을 수 없습니다.");
+    }
+
+    if (expectedAddress && account.toLowerCase() !== expectedAddress.toLowerCase()) {
+      throw new Error("입력한 지갑 주소와 메타마스크 선택 계정이 다릅니다.");
+    }
+
+    return { account, signature };
+  }
+
+  const provider = await getEthereumProvider();
+  const accounts = (await provider.request({ method: "eth_requestAccounts" })) as string[];
+  const account = String(accounts[0] ?? "").trim();
+
+  if (!account) {
+    throw new Error("메타마스크 계정을 찾을 수 없습니다.");
+  }
+
+  if (expectedAddress && account.toLowerCase() !== expectedAddress.toLowerCase()) {
+    throw new Error("입력한 지갑 주소와 메타마스크 선택 계정이 다릅니다.");
+  }
+
+  const signature = (await provider.request({
+    method: "personal_sign",
+    params: [message, account],
+  })) as string;
+
+  return { account, signature };
 };


### PR DESCRIPTION
## 변경 내용

1. 모바일 로그인 복귀 흐름 보완

- src/features/auth/login/useWalletLogin.ts
- 앱 전환/복귀 시 로그인 단계가 끊기던 흐름 안정화
2. MetaMask 모바일 연결 옵션 보완

- src/features/auth/wallet/ethereumProvider.ts
- 모바일 환경 연결/서명 흐름 보강
3. 사이드바 활성 상태 중복 표시 수정

- src/components/chat/Sidebar.tsx
- /campus/collection에서 Campus Map까지 같이 활성화되던 문제